### PR TITLE
The issue with the props "colors" has been fixed.

### DIFF
--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -44,7 +44,7 @@ function SinglePalette( {
 	actions,
 }: SinglePaletteProps ) {
 	const colorOptions = useMemo( () => {
-		return colors.map( ( { color, name }, index ) => {
+		return colors?.map( ( { color, name }, index ) => {
 			const colordColor = colord( color );
 			const isSelected = value === color;
 


### PR DESCRIPTION
The issue with the props "colors" has been fixed.

## What?
The issue with the props "colors" has been fixed.

## Why?
I can see that the documentation is showing that the props "colors" doesn't require any default value, but in WordPress 6.1 it seems to be generating an error when I don't insert any value for the props "colors" by default.

Previous Version : https://github.com/WordPress/gutenberg/blob/release/6.0/packages/components/src/color-palette/index.js

Trunk Version: https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/color-palette/index.tsx

Documentation: https://developer.wordpress.org/block-editor/reference-guides/components/color-palette/

## Screenshots or screencast
![color_plate_error](https://user-images.githubusercontent.com/10365575/200114649-6a2f6c19-2221-44fc-99f4-873098a52040.png)
